### PR TITLE
[FIX] gems/aws-s3-0.6.2/lib/aws/s3/extensions.rb:84: invalid multibyte e...

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -1,3 +1,4 @@
+# encoding: BINARY
 #:stopdoc:
 
 class Hash


### PR DESCRIPTION
...scape: /[\x80-\xFF]/